### PR TITLE
Disable ra (recursion available) and ad (authenticated data) dns flags

### DIFF
--- a/dns/ns.py
+++ b/dns/ns.py
@@ -69,7 +69,8 @@ class Resolver:
 
     def resolve(self, request: DNSRecord, handler: Any) -> DNSRecord:
         reply: DNSRecord = request.reply()
-
+        reply.header.ra = 0
+        reply.header.ad = 0
         # We assume that the data in the DB is correct (using server side checks)
         new_records: list[Record] = []
 


### PR DESCRIPTION
reply.header.ra = 0  # Disable Recursion Available flag to prevent DDoS reflection/amplification attacks using requestrepo dns server

reply.header.ad = 0  # Disable Authenticated Data flag so dnslib does not support DNSSEC validation at all

check dns recursion with:
```
dig @<vps-ip> google.com
```

## Before:

![before](https://github.com/user-attachments/assets/5ae13a67-a407-4c47-84aa-d05be7365203)

## After:

![after](https://github.com/user-attachments/assets/034605c5-5a27-49c5-9bf3-392e9c87848f)
