### PR TITLE
fix: security audit round 5 + email display bugs

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -15,7 +15,7 @@ jobs:
       run:
         working-directory: src
     env:
-      JWT_SECRET: test_secret_for_ci
+      JWT_SECRET: test_secret_for_ci_minimum_32_characters
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -21,7 +21,7 @@ jobs:
       run:
         working-directory: src
     env:
-      JWT_SECRET: test_secret_for_ci
+      JWT_SECRET: test_secret_for_ci_minimum_32_characters
     steps:
       - uses: actions/checkout@v4
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -269,7 +269,7 @@ interface Request {
 
 | Variable | Description |
 |----------|-------------|
-| `JWT_SECRET` | **Required.** Secret key for JWT signing (min 32 chars recommended). Server will fail to start if not set. |
+| `JWT_SECRET` | **Required.** Secret key for JWT signing (min 32 chars enforced). Server panics if <32 chars or a known placeholder. |
 | `DOMAIN` | Base domain (e.g., `requestrepo.com`) |
 | `SERVER_IP` | Public IP for DNS responses |
 

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ test: test-backend test-frontend
 
 .PHONY: test-backend
 test-backend:
-	cd $(RUST_DIR) && JWT_SECRET=test_secret_for_ci cargo test
+	cd $(RUST_DIR) && JWT_SECRET=test_secret_for_ci_minimum_32_characters cargo test
 
 .PHONY: test-frontend
 test-frontend:

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -31,25 +31,27 @@ declare global {
   }
 }
 
+const scrubSensitiveParams = (url: string): string => {
+  try {
+    const u = new URL(url, window.location.origin);
+    u.searchParams.delete("token");
+    u.searchParams.delete("share");
+    return u.toString();
+  } catch {
+    return url;
+  }
+};
+
 if (window.__CONFIG__?.SENTRY_DSN_FRONTEND) {
   Sentry.init({
     dsn: window.__CONFIG__.SENTRY_DSN_FRONTEND,
     beforeBreadcrumb(breadcrumb) {
-      const scrub = (url: string) => {
-        try {
-          const u = new URL(url, window.location.origin);
-          u.searchParams.delete("token");
-          u.searchParams.delete("share");
-          return u.toString();
-        } catch {
-          return url;
-        }
-      };
       if (breadcrumb.data?.url)
-        breadcrumb.data.url = scrub(breadcrumb.data.url);
+        breadcrumb.data.url = scrubSensitiveParams(breadcrumb.data.url);
       if (breadcrumb.data?.from)
-        breadcrumb.data.from = scrub(breadcrumb.data.from);
-      if (breadcrumb.data?.to) breadcrumb.data.to = scrub(breadcrumb.data.to);
+        breadcrumb.data.from = scrubSensitiveParams(breadcrumb.data.from);
+      if (breadcrumb.data?.to)
+        breadcrumb.data.to = scrubSensitiveParams(breadcrumb.data.to);
       return breadcrumb;
     },
     beforeSend(event, hint) {
@@ -68,16 +70,8 @@ if (window.__CONFIG__?.SENTRY_DSN_FRONTEND) {
       ) {
         return null;
       }
-      // Scrub sensitive params from event URL
       if (event.request?.url) {
-        try {
-          const u = new URL(event.request.url);
-          u.searchParams.delete("token");
-          u.searchParams.delete("share");
-          event.request.url = u.toString();
-        } catch {
-          /* ignore */
-        }
+        event.request.url = scrubSensitiveParams(event.request.url);
       }
       return event;
     },

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -35,15 +35,22 @@ if (window.__CONFIG__?.SENTRY_DSN_FRONTEND) {
   Sentry.init({
     dsn: window.__CONFIG__.SENTRY_DSN_FRONTEND,
     beforeBreadcrumb(breadcrumb) {
-      if (breadcrumb.category === "xhr" && breadcrumb.data?.url) {
+      const scrub = (url: string) => {
         try {
-          const url = new URL(breadcrumb.data.url, window.location.origin);
-          url.searchParams.delete("token");
-          breadcrumb.data.url = url.toString();
+          const u = new URL(url, window.location.origin);
+          u.searchParams.delete("token");
+          u.searchParams.delete("share");
+          return u.toString();
         } catch {
-          /* ignore malformed URLs */
+          return url;
         }
-      }
+      };
+      if (breadcrumb.data?.url)
+        breadcrumb.data.url = scrub(breadcrumb.data.url);
+      if (breadcrumb.data?.from)
+        breadcrumb.data.from = scrub(breadcrumb.data.from);
+      if (breadcrumb.data?.to)
+        breadcrumb.data.to = scrub(breadcrumb.data.to);
       return breadcrumb;
     },
     beforeSend(event, hint) {
@@ -61,6 +68,17 @@ if (window.__CONFIG__?.SENTRY_DSN_FRONTEND) {
         (error instanceof Event && error.type === "error")
       ) {
         return null;
+      }
+      // Scrub sensitive params from event URL
+      if (event.request?.url) {
+        try {
+          const u = new URL(event.request.url);
+          u.searchParams.delete("token");
+          u.searchParams.delete("share");
+          event.request.url = u.toString();
+        } catch {
+          /* ignore */
+        }
       }
       return event;
     },

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -49,8 +49,7 @@ if (window.__CONFIG__?.SENTRY_DSN_FRONTEND) {
         breadcrumb.data.url = scrub(breadcrumb.data.url);
       if (breadcrumb.data?.from)
         breadcrumb.data.from = scrub(breadcrumb.data.from);
-      if (breadcrumb.data?.to)
-        breadcrumb.data.to = scrub(breadcrumb.data.to);
+      if (breadcrumb.data?.to) breadcrumb.data.to = scrub(breadcrumb.data.to);
       return breadcrumb;
     },
     beforeSend(event, hint) {

--- a/frontend/src/pages/RequestsPage.tsx
+++ b/frontend/src/pages/RequestsPage.tsx
@@ -659,7 +659,7 @@ export function RequestsPage() {
               >
                 <Tab key="text" title="Text">
                   <Code className="block whitespace-pre-wrap p-2 text-xs font-mono mb-4 overflow-x-auto">
-                    {selectedRequest.text_body || selectedRequest.data || ""}
+                    {selectedRequest.text_body || "No text body available"}
                   </Code>
                 </Tab>
                 <Tab key="html" title="HTML">
@@ -733,9 +733,6 @@ export function RequestsPage() {
 
           {/* Raw SMTP Transaction */}
           <h3 className="text-base font-semibold mb-2">Raw SMTP Transaction</h3>
-          <Code className="block p-3 text-xs mb-2 overflow-x-auto break-all">
-            {selectedRequest.raw}
-          </Code>
           <Code className="block whitespace-pre-wrap p-2 text-xs font-mono overflow-x-auto">
             {rawDecoded.text}
           </Code>

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -48,7 +48,7 @@ serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.114"
 
 # JWT
-jsonwebtoken = "9.2.0"
+jsonwebtoken = "9.3"
 
 # Compression
 flate2 = "1.0.28"

--- a/src/src/cache/mod.rs
+++ b/src/src/cache/mod.rs
@@ -122,7 +122,16 @@ impl Cache {
         // Check per-subdomain limit for session data (files:*, dns:*)
         if let Some(subdomain) = extract_subdomain_from_key(key) {
             let current_size = self.get_subdomain_size(&subdomain);
-            if current_size + uncompressed_size > CONFIG.max_subdomain_size_bytes {
+            // Subtract old entry size if replacing an existing key
+            let old_size = self
+                .kv_store
+                .read()
+                .ok()
+                .and_then(|s| s.get(key).map(|e| e.uncompressed_size))
+                .unwrap_or(0);
+            if current_size.saturating_sub(old_size) + uncompressed_size
+                > CONFIG.max_subdomain_size_bytes
+            {
                 return Err(anyhow!(
                     "Subdomain {} storage limit exceeded ({} bytes max)",
                     subdomain,

--- a/src/src/http/routes.rs
+++ b/src/src/http/routes.rs
@@ -285,7 +285,14 @@ fn resolve_file_path<'a>(
 
 /// Headers that are blocked on main domain path-based routing for security
 /// Service-Worker-Allowed: Can be abused to register a SW controlling the entire domain
-const BLOCKED_HEADERS_ON_MAIN_DOMAIN: &[&str] = &["service-worker-allowed"];
+const BLOCKED_HEADERS_ON_MAIN_DOMAIN: &[&str] = &[
+    "service-worker-allowed",
+    "set-cookie",
+    "set-cookie2",
+    "location",
+    "content-security-policy",
+    "content-security-policy-report-only",
+];
 
 /// Serve a file from the subdomain's file tree
 /// `on_main_domain`: true when using path-based routing (/r/subdomain/), false for subdomain routing

--- a/src/src/smtp/mod.rs
+++ b/src/src/smtp/mod.rs
@@ -4,7 +4,7 @@ use mail_parser::{MessageParser, MimeHeaders};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::{broadcast, Semaphore};
 use tokio::time::timeout;
@@ -97,6 +97,38 @@ impl Server {
     }
 }
 
+/// Read a line from the reader with a maximum length limit.
+/// Unlike `read_line()`, this enforces the limit DURING the read,
+/// preventing unbounded memory allocation from newline-free input.
+async fn read_line_limited<R: AsyncBufRead + Unpin>(
+    reader: &mut R,
+    buf: &mut String,
+    max_len: usize,
+) -> std::io::Result<usize> {
+    let mut total = 0;
+    loop {
+        let available = reader.fill_buf().await?;
+        if available.is_empty() {
+            return Ok(total); // EOF
+        }
+        let remaining = max_len + 1 - total;
+        let to_scan = available.len().min(remaining);
+        if let Some(pos) = available[..to_scan].iter().position(|&b| b == b'\n') {
+            let to_consume = pos + 1;
+            buf.push_str(&String::from_utf8_lossy(&available[..to_consume]));
+            reader.consume(to_consume);
+            total += to_consume;
+            return Ok(total);
+        }
+        buf.push_str(&String::from_utf8_lossy(&available[..to_scan]));
+        reader.consume(to_scan);
+        total += to_scan;
+        if total > max_len {
+            return Ok(total); // Hit limit, caller will disconnect
+        }
+    }
+}
+
 /// Extract subdomain from an email address like "user@subdomain.domain.com"
 fn extract_subdomain_from_email(email: &str) -> Option<String> {
     // Remove angle brackets if present: <user@domain> -> user@domain
@@ -147,8 +179,9 @@ async fn handle_smtp_connection(
     loop {
         line.clear();
 
-        // Read with timeout
-        let read_result = timeout(READ_TIMEOUT, reader.read_line(&mut line)).await;
+        // Read with timeout, enforcing max line length during the read
+        let read_result =
+            timeout(READ_TIMEOUT, read_line_limited(&mut reader, &mut line, MAX_LINE_LENGTH)).await;
 
         let bytes_read = match read_result {
             Ok(Ok(n)) => n,
@@ -167,7 +200,7 @@ async fn handle_smtp_connection(
             break;
         }
 
-        // Check line length
+        // Line length is bounded by read_line_limited, but check for overlength
         if line.len() > MAX_LINE_LENGTH {
             let _ = writer.write_all(b"500 Line too long\r\n").await;
             break;
@@ -193,7 +226,10 @@ async fn handle_smtp_connection(
         }
 
         if data_mode {
-            if line_trimmed == "." {
+            // In data mode, only strip trailing whitespace to preserve leading
+            // whitespace needed for MIME header folding (RFC 2822 continuation lines)
+            let data_line = line.trim_end();
+            if data_line == "." {
                 data_mode = false;
                 transaction_log.push_str("C: .\n");
                 transaction_log.push_str("S: 250 OK: Message received\n");
@@ -233,7 +269,7 @@ async fn handle_smtp_connection(
                 writer.write_all(b"250 OK: Message received\r\n").await?;
             } else {
                 // Check message size
-                if email_data.len() + line.len() > MAX_MESSAGE_SIZE {
+                if email_data.len() + data_line.len() > MAX_MESSAGE_SIZE {
                     data_mode = false;
                     transaction_log.push_str("S: 552 Message size exceeds maximum\n");
                     writer
@@ -244,7 +280,7 @@ async fn handle_smtp_connection(
 
                 // Handle dot-stuffing (lines starting with . have the . removed)
                 // Preserve \r\n line endings for correct MIME parsing
-                let content = line_trimmed.strip_prefix('.').unwrap_or(line_trimmed);
+                let content = data_line.strip_prefix('.').unwrap_or(data_line);
                 email_data.push_str(content);
                 email_data.push_str("\r\n");
             }

--- a/src/src/smtp/mod.rs
+++ b/src/src/smtp/mod.rs
@@ -180,8 +180,11 @@ async fn handle_smtp_connection(
         line.clear();
 
         // Read with timeout, enforcing max line length during the read
-        let read_result =
-            timeout(READ_TIMEOUT, read_line_limited(&mut reader, &mut line, MAX_LINE_LENGTH)).await;
+        let read_result = timeout(
+            READ_TIMEOUT,
+            read_line_limited(&mut reader, &mut line, MAX_LINE_LENGTH),
+        )
+        .await;
 
         let bytes_read = match read_result {
             Ok(Ok(n)) => n,

--- a/src/src/smtp/mod.rs
+++ b/src/src/smtp/mod.rs
@@ -111,7 +111,10 @@ async fn read_line_limited<R: AsyncBufRead + Unpin>(
         if available.is_empty() {
             return Ok(total); // EOF
         }
-        let remaining = max_len + 1 - total;
+        let remaining = (max_len + 1).saturating_sub(total);
+        if remaining == 0 {
+            return Ok(total);
+        }
         let to_scan = available.len().min(remaining);
         if let Some(pos) = available[..to_scan].iter().position(|&b| b == b'\n') {
             let to_consume = pos + 1;

--- a/src/src/tests/auth_tests.rs
+++ b/src/src/tests/auth_tests.rs
@@ -9,7 +9,7 @@ mod tests {
         // Skip if the env var is not configured
         if std::env::var("JWT_SECRET").is_err() {
             // Set a test secret temporarily
-            std::env::set_var("JWT_SECRET", "test_secret_for_testing_only");
+            std::env::set_var("JWT_SECRET", "test_secret_for_testing_only_min32");
         }
 
         let subdomain = "testsubdomain";

--- a/src/src/utils/config.rs
+++ b/src/src/utils/config.rs
@@ -69,6 +69,16 @@ impl Config {
             "JWT_SECRET environment variable is required. \
              Generate a secure random string (32+ chars) and set it before starting the server.",
         );
+        const KNOWN_PLACEHOLDERS: &[&str] = &[
+            "your-super-secret-jwt-key-change-this-min-32-chars",
+            "your-secret-key-min-32-chars",
+        ];
+        if jwt_secret.len() < 32 || KNOWN_PLACEHOLDERS.contains(&jwt_secret.as_str()) {
+            panic!(
+                "JWT_SECRET is insecure! It must be at least 32 characters and not a known placeholder.\n\
+                 Generate one with: openssl rand -base64 48"
+            );
+        }
         let txt_record = env::var("TXT").unwrap_or_else(|_| "Hello!".to_string());
         let http_port = env::var("HTTP_PORT")
             .unwrap_or_else(|_| "21337".to_string())


### PR DESCRIPTION
## Summary

- **SMTP bounded read**: Replace unbounded `read_line()` with `read_line_limited()` using `fill_buf()`/`consume()` — prevents OOM from newline-free input (AIS-ASO-REF-003)
- **SMTP whitespace preservation**: Use `trim_end()` instead of `trim()` in DATA mode to preserve MIME header folding — fixes HTML/text body extraction for multipart emails
- **Cache double-count fix**: Subtract old entry size before limit check in `set()` — prevents false "storage exceeded" on key replacement (AIS-ASO-REF-004)
- **Blocked headers expansion**: Block `Set-Cookie`, `Location`, `CSP` on main domain `/r/` routing (AIS-ASO-REF-009)
- **JWT_SECRET validation**: Reject known placeholders and enforce min 32 chars at startup (AIS-ASO-REF-002)
- **Sentry scrubbing**: Strip `token`/`share` params from all breadcrumb types + `event.request.url` (AIS-ASO-REF-005)
- **Frontend email display**: Fix text tab fallback showing raw email, remove squished base64 block from Raw SMTP view
- **jsonwebtoken**: Bump 9.2 → 9.3 for CVE-2026-25537 patch

## Test plan

- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` — 79 passed, 0 failed
- [x] `bun run lint` + `bun run tsc --noEmit` — clean
- [ ] Manual: send multipart email, verify HTML tab renders correctly
- [ ] Manual: verify Raw SMTP Transaction is readable (no squished base64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)