### PR TITLE
feat: add notification system with webhooks ( Discord, Mattermost, Telegram )

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -294,3 +294,7 @@ backend/ip2country
 dns/ip2country
 
 pyrightconfig.json
+
+
+.DS_Store
+**/.DS_Store

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "frontendv2",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import { BackendOfflineOverlay } from "@/components/auth/BackendOfflineOverlay";
 import { RequestsPage } from "@/pages/RequestsPage";
 import { ResponseEditorPage } from "@/pages/ResponseEditorPage";
 import { DnsSettingsPage } from "@/pages/DnsSettingsPage";
+import { NotificationsPage } from "@/pages/NotificationsPage";
 
 // Redirect that preserves query params (for share links)
 function RedirectWithParams() {
@@ -57,6 +58,7 @@ function App() {
           <Route path="requests" element={<RequestsPage />} />
           <Route path="response" element={<ResponseEditorPage />} />
           <Route path="dns" element={<DnsSettingsPage />} />
+          <Route path="notifications" element={<NotificationsPage />} />
           {/* Catch-all: redirect unknown routes to /requests */}
           <Route path="*" element={<Navigate to="/requests" replace />} />
         </Route>

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -3,6 +3,7 @@ import type {
   SessionCreateResponse,
   DnsRecord,
   FileTree,
+  NotificationSettings,
   PaginatedResponse,
   Request,
 } from "@/types";
@@ -172,6 +173,64 @@ export async function getSharedRequest(
   }
 }
 
+// Notification Settings API
+export async function getNotificationSettings(
+  token: string,
+): Promise<NotificationSettings> {
+  try {
+    const { data } = await api.get<NotificationSettings>(
+      "/notifications/settings",
+      { params: { token } },
+    );
+    return data;
+  } catch (error) {
+    if (isNetworkError(error)) {
+      return {
+        discord_webhook_url: "",
+        mattermost_webhook_url: "",
+        telegram_bot_token: "",
+        telegram_chat_id: "",
+      };
+    }
+    throw error;
+  }
+}
+
+export async function updateNotificationSettings(
+  token: string,
+  settings: NotificationSettings,
+): Promise<void> {
+  await api.put("/notifications/settings", settings, { params: { token } });
+}
+
+export async function sendTestNotification(
+  token: string,
+  service: string,
+): Promise<void> {
+  await api.post(
+    "/notifications/test",
+    {
+      message: "This is a test notification from RequestRepo",
+      title: "RequestRepo Test Notification",
+    },
+    { params: { token, service } },
+  );
+}
+
+export async function sendRequestNotification(
+  token: string,
+  service: string,
+  log: Record<string, unknown>,
+  message?: string,
+  title?: string,
+): Promise<void> {
+  await api.post(
+    "/notifications/send",
+    { log, message, title },
+    { params: { token, service } },
+  );
+}
+
 export const apiClient = {
   createSession,
   getDnsRecords,
@@ -184,4 +243,8 @@ export const apiClient = {
   getSharedRequest,
   deleteRequest,
   deleteAllRequests,
+  getNotificationSettings,
+  updateNotificationSettings,
+  sendTestNotification,
+  sendRequestNotification,
 };

--- a/frontend/src/components/layout/Toolbar.tsx
+++ b/frontend/src/components/layout/Toolbar.tsx
@@ -1,6 +1,6 @@
 import { useNavigate, useLocation } from "react-router-dom";
 import { Button, Input } from "@heroui/react";
-import { Download, FileEdit, Network, Copy, Shuffle } from "lucide-react";
+import { Download, FileEdit, Network, Bell, Copy, Shuffle } from "lucide-react";
 import { toast } from "sonner";
 import { useSessionStore } from "@/stores/sessionStore";
 import { useAuthStore } from "@/stores/authStore";
@@ -53,6 +53,7 @@ export function Toolbar() {
     { key: "requests", label: "Requests", icon: Download },
     { key: "response", label: "Response", icon: FileEdit },
     { key: "dns", label: "DNS", icon: Network },
+    { key: "notifications", label: "Notifications", icon: Bell },
   ];
 
   return (

--- a/frontend/src/pages/NotificationsPage.tsx
+++ b/frontend/src/pages/NotificationsPage.tsx
@@ -1,0 +1,263 @@
+import { useState, useEffect } from "react";
+import {
+  Card,
+  CardBody,
+  CardHeader,
+  Button,
+  Input,
+  Divider,
+} from "@heroui/react";
+import { Eye, EyeOff, Copy, X, Save, Bell } from "lucide-react";
+import { toast } from "sonner";
+import { useSessionStore } from "@/stores/sessionStore";
+import { apiClient } from "@/api/client";
+import { copyToClipboard } from "@/lib/utils";
+import type { NotificationSettings } from "@/types";
+
+export function NotificationsPage() {
+  const sessions = useSessionStore((s) => s.sessions);
+  const activeSubdomain = useSessionStore((s) => s.activeSubdomain);
+  const session = sessions.find((s) => s.subdomain === activeSubdomain);
+
+  const [settings, setSettings] = useState<NotificationSettings>({
+    discord_webhook_url: "",
+    mattermost_webhook_url: "",
+    telegram_bot_token: "",
+    telegram_chat_id: "",
+  });
+  const [loading, setLoading] = useState(false);
+  const [showDiscord, setShowDiscord] = useState(false);
+  const [showMattermost, setShowMattermost] = useState(false);
+  const [showTelegramToken, setShowTelegramToken] = useState(false);
+  const [showTelegramChat, setShowTelegramChat] = useState(false);
+
+  useEffect(() => {
+    if (!session?.token) return;
+    const load = async () => {
+      try {
+        const data = await apiClient.getNotificationSettings(session.token);
+        setSettings(data);
+      } catch {
+        toast.error("Failed to load notification settings");
+      }
+    };
+    load();
+  }, [session?.token]);
+
+  const handleSave = async () => {
+    if (!session?.token) {
+      toast.error("No active session");
+      return;
+    }
+    setLoading(true);
+    try {
+      await apiClient.updateNotificationSettings(session.token, settings);
+      toast.success("Notification settings saved");
+    } catch {
+      toast.error("Failed to save notification settings");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleTest = async (service: string) => {
+    if (!session?.token) {
+      toast.error("No active session");
+      return;
+    }
+    setLoading(true);
+    try {
+      await apiClient.sendTestNotification(session.token, service);
+      toast.success(`Test ${service} notification sent`);
+    } catch (err) {
+      const msg =
+        err instanceof Error
+          ? err.message
+          : `Failed to send test ${service} notification`;
+      toast.error(msg);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleCopy = (value: string) => {
+    copyToClipboard(value);
+    toast.success("Copied to clipboard");
+  };
+
+  if (!session) {
+    return <div>No session selected</div>;
+  }
+
+  const field = (
+    label: string,
+    id: string,
+    value: string,
+    onChange: (v: string) => void,
+    placeholder: string,
+    show: boolean,
+    onToggle: () => void,
+  ) => (
+    <div className="flex flex-col gap-2">
+      <label htmlFor={id} className="text-sm font-medium text-default-700">
+        {label}
+      </label>
+      <Input
+        id={id}
+        type={show ? "text" : "password"}
+        value={value}
+        onValueChange={onChange}
+        placeholder={placeholder}
+        size="sm"
+        endContent={
+          <div className="flex items-center gap-1">
+            <Button
+              isIconOnly
+              size="sm"
+              variant="light"
+              onPress={onToggle}
+              className="text-default-400"
+            >
+              {show ? (
+                <EyeOff className="h-4 w-4" />
+              ) : (
+                <Eye className="h-4 w-4" />
+              )}
+            </Button>
+            <Button
+              isIconOnly
+              size="sm"
+              variant="light"
+              onPress={() => handleCopy(value)}
+              className="text-default-400"
+            >
+              <Copy className="h-4 w-4" />
+            </Button>
+            <Button
+              isIconOnly
+              size="sm"
+              variant="light"
+              onPress={() => onChange("")}
+              className="text-default-400"
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
+        }
+      />
+    </div>
+  );
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Card>
+        <CardBody className="gap-2">
+          <div className="flex items-center gap-2">
+            <Bell className="h-5 w-5 text-primary" />
+            <h2 className="text-lg font-semibold">Notification Settings</h2>
+          </div>
+          <p className="text-sm text-default-500">
+            Configure webhook URLs for Discord, Mattermost, and Telegram
+            notifications.
+          </p>
+        </CardBody>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <h3 className="text-base font-semibold">Webhooks & Tokens</h3>
+        </CardHeader>
+        <Divider />
+        <CardBody className="flex flex-col gap-6">
+          {field(
+            "Discord Webhook URL",
+            "discord-webhook",
+            settings.discord_webhook_url,
+            (v) => setSettings((s) => ({ ...s, discord_webhook_url: v })),
+            "https://discord.com/api/webhooks/...",
+            showDiscord,
+            () => setShowDiscord(!showDiscord),
+          )}
+
+          {field(
+            "Mattermost Webhook URL",
+            "mattermost-webhook",
+            settings.mattermost_webhook_url,
+            (v) => setSettings((s) => ({ ...s, mattermost_webhook_url: v })),
+            "https://your-mattermost-instance.com/hooks/...",
+            showMattermost,
+            () => setShowMattermost(!showMattermost),
+          )}
+
+          {field(
+            "Telegram Bot Token",
+            "telegram-bot-token",
+            settings.telegram_bot_token,
+            (v) => setSettings((s) => ({ ...s, telegram_bot_token: v })),
+            "Enter your Telegram bot token",
+            showTelegramToken,
+            () => setShowTelegramToken(!showTelegramToken),
+          )}
+
+          {field(
+            "Telegram Chat ID",
+            "telegram-chat-id",
+            settings.telegram_chat_id,
+            (v) => setSettings((s) => ({ ...s, telegram_chat_id: v })),
+            "Enter your Telegram chat ID",
+            showTelegramChat,
+            () => setShowTelegramChat(!showTelegramChat),
+          )}
+
+          <Button
+            color="primary"
+            startContent={<Save className="h-4 w-4" />}
+            onPress={handleSave}
+            isLoading={loading}
+            className="w-full md:w-auto md:self-start"
+          >
+            Save Settings
+          </Button>
+        </CardBody>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <h3 className="text-base font-semibold">Test Notifications</h3>
+        </CardHeader>
+        <Divider />
+        <CardBody>
+          <div className="flex flex-wrap gap-3">
+            <Button
+              startContent={<Bell className="h-4 w-4" />}
+              onPress={() => handleTest("discord")}
+              isLoading={loading}
+              className="text-white"
+              style={{ backgroundColor: "#5865F2" }}
+            >
+              Test Discord
+            </Button>
+            <Button
+              startContent={<Bell className="h-4 w-4" />}
+              onPress={() => handleTest("mattermost")}
+              isLoading={loading}
+              className="text-white"
+              style={{ backgroundColor: "#1E325C" }}
+            >
+              Test Mattermost
+            </Button>
+            <Button
+              startContent={<Bell className="h-4 w-4" />}
+              onPress={() => handleTest("telegram")}
+              isLoading={loading}
+              className="text-white"
+              style={{ backgroundColor: "#229ED9" }}
+            >
+              Test Telegram
+            </Button>
+          </div>
+        </CardBody>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/pages/RequestsPage.tsx
+++ b/frontend/src/pages/RequestsPage.tsx
@@ -1,6 +1,13 @@
 import { useEffect, useState } from "react";
 import { Card, CardBody, Code, Button, Tabs, Tab, Chip } from "@heroui/react";
-import { Share2, Copy, Check } from "lucide-react";
+import {
+  Share2,
+  Copy,
+  Check,
+  MessageCircle,
+  MessageSquare,
+  Send,
+} from "lucide-react";
 import { toast } from "sonner";
 import Editor from "@monaco-editor/react";
 import { useSessionStore } from "@/stores/sessionStore";
@@ -124,6 +131,56 @@ export function RequestsPage() {
     }
   };
 
+  const sendToService = async (service: string) => {
+    if (!selectedRequest || !session?.token || isSharedRequestView) return;
+    try {
+      await apiClient.sendRequestNotification(
+        session.token,
+        service,
+        selectedRequest as unknown as Record<string, unknown>,
+      );
+      toast.success(`Sent to ${service}`);
+    } catch (error) {
+      console.error(`Failed to send to ${service}:`, error);
+      const msg =
+        error instanceof Error ? error.message : `Failed to send to ${service}`;
+      toast.error(msg);
+    }
+  };
+
+  const notificationButtons =
+    !isSharedRequestView && selectedRequest ? (
+      <div className="flex items-center gap-1">
+        <button
+          onClick={() => sendToService("discord")}
+          className="h-7 w-7 rounded-full border-0 flex items-center justify-center cursor-pointer"
+          style={{ backgroundColor: "#5865F2" }}
+          title="Send to Discord"
+          type="button"
+        >
+          <MessageCircle className="h-3.5 w-3.5 text-white" />
+        </button>
+        <button
+          onClick={() => sendToService("mattermost")}
+          className="h-7 w-7 rounded-full border-0 flex items-center justify-center cursor-pointer"
+          style={{ backgroundColor: "#1E325C" }}
+          title="Send to Mattermost"
+          type="button"
+        >
+          <MessageSquare className="h-3.5 w-3.5 text-white" />
+        </button>
+        <button
+          onClick={() => sendToService("telegram")}
+          className="h-7 w-7 rounded-full border-0 flex items-center justify-center cursor-pointer"
+          style={{ backgroundColor: "#229ED9" }}
+          title="Send to Telegram"
+          type="button"
+        >
+          <Send className="h-3.5 w-3.5 text-white" />
+        </button>
+      </div>
+    ) : null;
+
   // Show "Awaiting requests" when no request selected
   if (!selectedRequest) {
     return (
@@ -242,18 +299,20 @@ export function RequestsPage() {
     return (
       <Card className="h-full overflow-auto">
         <CardBody className="p-4 relative">
-          {/* Share button - only show if user has the session */}
+          {/* Share + Notification buttons */}
           {!isSharedRequestView && (
-            <Button
-              isIconOnly
-              size="sm"
-              variant="light"
-              onPress={handleShareRequest}
-              className="absolute right-4 top-4"
-              title="Share request"
-            >
-              <Share2 className="h-4 w-4" />
-            </Button>
+            <div className="absolute right-4 top-4 flex items-center gap-1">
+              <Button
+                isIconOnly
+                size="sm"
+                variant="light"
+                onPress={handleShareRequest}
+                title="Share request"
+              >
+                <Share2 className="h-4 w-4" />
+              </Button>
+              {notificationButtons}
+            </div>
           )}
 
           {/* Shared request banner */}
@@ -411,18 +470,20 @@ export function RequestsPage() {
     return (
       <Card className="h-full overflow-auto">
         <CardBody className="p-4 relative">
-          {/* Share button - only show if user has the session */}
+          {/* Share + Notification buttons */}
           {!isSharedRequestView && (
-            <Button
-              isIconOnly
-              size="sm"
-              variant="light"
-              onPress={handleShareRequest}
-              className="absolute right-4 top-4"
-              title="Share request"
-            >
-              <Share2 className="h-4 w-4" />
-            </Button>
+            <div className="absolute right-4 top-4 flex items-center gap-1">
+              <Button
+                isIconOnly
+                size="sm"
+                variant="light"
+                onPress={handleShareRequest}
+                title="Share request"
+              >
+                <Share2 className="h-4 w-4" />
+              </Button>
+              {notificationButtons}
+            </div>
           )}
 
           {/* Shared request banner */}
@@ -531,18 +592,20 @@ export function RequestsPage() {
     return (
       <Card className="h-full overflow-auto">
         <CardBody className="p-4 relative">
-          {/* Share button - only show if user has the session */}
+          {/* Share + Notification buttons */}
           {!isSharedRequestView && (
-            <Button
-              isIconOnly
-              size="sm"
-              variant="light"
-              onPress={handleShareRequest}
-              className="absolute right-4 top-4"
-              title="Share request"
-            >
-              <Share2 className="h-4 w-4" />
-            </Button>
+            <div className="absolute right-4 top-4 flex items-center gap-1">
+              <Button
+                isIconOnly
+                size="sm"
+                variant="light"
+                onPress={handleShareRequest}
+                title="Share request"
+              >
+                <Share2 className="h-4 w-4" />
+              </Button>
+              {notificationButtons}
+            </div>
           )}
 
           {/* Shared request banner */}

--- a/frontend/src/pages/index.ts
+++ b/frontend/src/pages/index.ts
@@ -1,3 +1,4 @@
 export { RequestsPage } from "./RequestsPage";
 export { ResponseEditorPage } from "./ResponseEditorPage";
 export { DnsSettingsPage } from "./DnsSettingsPage";
+export { NotificationsPage } from "./NotificationsPage";

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -111,6 +111,14 @@ export interface PaginatedResponse<T> {
   };
 }
 
+// Notification settings
+export interface NotificationSettings {
+  discord_webhook_url: string;
+  mattermost_webhook_url: string;
+  telegram_bot_token: string;
+  telegram_chat_id: string;
+}
+
 // WebSocket types
 export type WebSocketClientMessage =
   | { cmd: "connect"; token: string }

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1236,9 +1236,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.5.10",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2353,6 +2355,7 @@ dependencies = [
  "rand 0.8.5",
  "rcgen 0.13.2",
  "regex",
+ "reqwest",
  "rustls",
  "rustls-pemfile",
  "sentry",
@@ -2383,17 +2386,21 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http 1.3.1",
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
@@ -2950,6 +2957,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3693,7 +3721,7 @@ dependencies = [
  "windows-interface",
  "windows-link 0.1.1",
  "windows-result",
- "windows-strings",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -3731,10 +3759,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-registry"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
+dependencies = [
+ "windows-result",
+ "windows-strings 0.3.1",
+ "windows-targets 0.53.5",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
  "windows-link 0.1.1",
 ]

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -555,6 +555,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,6 +650,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1036,8 +1056,22 @@ checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.2.0",
  "wasi 0.14.2+wasi-0.2.4",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1583,6 +1617,12 @@ checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mail-parser"
@@ -2183,6 +2223,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2 0.6.1",
+ "thiserror 2.0.12",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.12",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.1",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2196,6 +2293,12 @@ name = "r-efi"
 version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -2216,6 +2319,17 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2254,6 +2368,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.3",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2355,7 +2484,7 @@ dependencies = [
  "rand 0.8.5",
  "rcgen 0.13.2",
  "regex",
- "reqwest",
+ "reqwest 0.13.4",
  "rustls",
  "rustls-pemfile",
  "sentry",
@@ -2386,21 +2515,17 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
  "http 1.3.1",
  "http-body",
  "http-body-util",
  "hyper",
- "hyper-rustls",
  "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "mime",
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
@@ -2411,6 +2536,46 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tower 0.5.2",
+ "tower-http 0.6.8",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "h2",
+ "http 1.3.1",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
  "tower 0.5.2",
  "tower-http 0.6.8",
  "tower-service",
@@ -2445,6 +2610,12 @@ name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -2519,6 +2690,7 @@ version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -2647,7 +2819,7 @@ checksum = "2f925d575b468e88b079faf590a8dd0c9c99e2ec29e9bab663ceb8b45056312f"
 dependencies = [
  "httpdate",
  "native-tls",
- "reqwest",
+ "reqwest 0.12.28",
  "sentry-actix",
  "sentry-backtrace",
  "sentry-contexts",
@@ -2835,7 +3007,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3642,6 +3814,16 @@ name = "web-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -71,7 +71,7 @@ sentry = "0.46"
 sentry-tower = { version = "0.46", features = ["http"] }
 
 # HTTP client (for outbound notifications to Discord/Telegram/Mattermost)
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.13.4", features = ["json"] }
 
 # Utilities
 rand = "0.8.5"

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -70,6 +70,9 @@ mail-parser = "0.9"
 sentry = "0.46"
 sentry-tower = { version = "0.46", features = ["http"] }
 
+# HTTP client (for outbound notifications to Discord/Telegram/Mattermost)
+reqwest = { version = "0.12", features = ["json"] }
+
 # Utilities
 rand = "0.8.5"
 chrono = { version = "0.4.35", features = ["serde"] }

--- a/src/src/dns/mod.rs
+++ b/src/src/dns/mod.rs
@@ -394,6 +394,18 @@ async fn log_dns_request(
     let list_key = format!("requests:{subdomain}");
     cache.rpush(&list_key, &request_json).await?;
 
+    // Send notifications asynchronously
+    {
+        let cache = cache.clone();
+        let sub = subdomain.to_string();
+        let req_json = request_json.clone();
+        tokio::spawn(async move {
+            if let Ok(log) = serde_json::from_str::<serde_json::Value>(&req_json) {
+                crate::notifications::notify_all(cache, sub, log).await;
+            }
+        });
+    }
+
     let message = CacheMessage {
         cmd: "new_request".to_string(),
         subdomain: subdomain.to_string(),

--- a/src/src/http/mod.rs
+++ b/src/src/http/mod.rs
@@ -135,6 +135,18 @@ fn create_router(state: AppState) -> Router {
             "/api/v2/requests/:id",
             get(routes_v2::get_request).delete(routes_v2::delete_request),
         )
+        .route(
+            "/api/v2/notifications/settings",
+            get(routes_v2::get_notification_settings).put(routes_v2::update_notification_settings),
+        )
+        .route(
+            "/api/v2/notifications/test",
+            post(routes_v2::test_notification),
+        )
+        .route(
+            "/api/v2/notifications/send",
+            post(routes_v2::send_notification),
+        )
         .route("/api/v2/ws", get(websocket::websocket_handler_v2))
         .layer(cors);
 

--- a/src/src/http/routes.rs
+++ b/src/src/http/routes.rs
@@ -186,6 +186,18 @@ pub async fn catch_all(
         let list_key = format!("requests:{subdomain}");
         let _ = state.cache.rpush(&list_key, &request_json).await;
 
+        // Send notifications asynchronously
+        {
+            let cache = state.cache.clone();
+            let sub = subdomain.clone();
+            let req_json = request_json.clone();
+            tokio::spawn(async move {
+                if let Ok(log) = serde_json::from_str::<serde_json::Value>(&req_json) {
+                    crate::notifications::notify_all(cache, sub, log).await;
+                }
+            });
+        }
+
         let message = crate::models::CacheMessage {
             cmd: "new_request".to_string(),
             subdomain: subdomain.clone(),

--- a/src/src/http/routes_v2.rs
+++ b/src/src/http/routes_v2.rs
@@ -15,7 +15,7 @@ use std::collections::HashMap;
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 
 use crate::http::AppState;
-use crate::models::{DnsRecord, DnsRecords, FileTree};
+use crate::models::{DnsRecord, DnsRecords, FileTree, NotificationSettings};
 use crate::utils::config::CONFIG;
 use crate::utils::{
     auth::{can_create_session, is_admin_token_required},
@@ -1036,6 +1036,153 @@ pub async fn get_shared_request(
         })),
     )
         .into_response()
+}
+
+// ============================================================================
+// Notification Routes
+// ============================================================================
+
+/// GET /api/v2/notifications/settings - Get notification settings
+pub async fn get_notification_settings(
+    State(state): State<AppState>,
+    Query(query): Query<TokenQuery>,
+    headers: axum::http::HeaderMap,
+) -> impl IntoResponse {
+    let subdomain = match verify_token_or_error(&query, &headers) {
+        Ok(s) => s,
+        Err(e) => return e.into_response(),
+    };
+
+    let settings = crate::notifications::get_settings(&state.cache, &subdomain).await;
+    (StatusCode::OK, Json(settings)).into_response()
+}
+
+/// PUT /api/v2/notifications/settings - Update notification settings
+pub async fn update_notification_settings(
+    State(state): State<AppState>,
+    Query(query): Query<TokenQuery>,
+    headers: axum::http::HeaderMap,
+    Json(settings): Json<NotificationSettings>,
+) -> impl IntoResponse {
+    let subdomain = match verify_token_or_error(&query, &headers) {
+        Ok(s) => s,
+        Err(e) => return e.into_response(),
+    };
+
+    match crate::notifications::save_settings(&state.cache, &subdomain, &settings).await {
+        Ok(_) => (
+            StatusCode::OK,
+            Json(json!({ "message": "Notification settings updated" })),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({
+                "error": e,
+                "code": "storage_error"
+            })),
+        )
+            .into_response(),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TestNotificationQuery {
+    pub token: Option<String>,
+    pub service: String,
+}
+
+/// POST /api/v2/notifications/test - Send a test notification
+pub async fn test_notification(
+    State(state): State<AppState>,
+    Query(query): Query<TestNotificationQuery>,
+    headers: axum::http::HeaderMap,
+) -> impl IntoResponse {
+    let token_query = TokenQuery {
+        token: query.token.clone(),
+    };
+    let subdomain = match verify_token_or_error(&token_query, &headers) {
+        Ok(s) => s,
+        Err(e) => return e.into_response(),
+    };
+
+    match crate::notifications::send_test(&state.cache, &subdomain, &query.service).await {
+        Ok(_) => (
+            StatusCode::OK,
+            Json(json!({ "message": format!("Test {} notification sent", query.service) })),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "error": e,
+                "code": "notification_error"
+            })),
+        )
+            .into_response(),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SendNotificationQuery {
+    pub token: Option<String>,
+    pub service: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SendNotificationBody {
+    pub log: Option<serde_json::Value>,
+    pub message: Option<String>,
+    pub title: Option<String>,
+}
+
+/// POST /api/v2/notifications/send - Send a request log as notification
+pub async fn send_notification(
+    State(state): State<AppState>,
+    Query(query): Query<SendNotificationQuery>,
+    headers: axum::http::HeaderMap,
+    Json(body): Json<SendNotificationBody>,
+) -> impl IntoResponse {
+    let token_query = TokenQuery {
+        token: query.token.clone(),
+    };
+    let subdomain = match verify_token_or_error(&token_query, &headers) {
+        Ok(s) => s,
+        Err(e) => return e.into_response(),
+    };
+
+    let log = body.log.unwrap_or_default();
+    let message = body
+        .message
+        .unwrap_or_else(|| "Notification from RequestRepo".to_string());
+    let title = body
+        .title
+        .unwrap_or_else(|| "RequestRepo Notification".to_string());
+
+    match crate::notifications::send_request_notification(
+        &state.cache,
+        &subdomain,
+        &query.service,
+        &log,
+        &message,
+        &title,
+    )
+    .await
+    {
+        Ok(_) => (
+            StatusCode::OK,
+            Json(json!({ "message": format!("{} notification sent", query.service) })),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "error": e,
+                "code": "notification_error"
+            })),
+        )
+            .into_response(),
+    }
 }
 
 // ============================================================================

--- a/src/src/lib.rs
+++ b/src/src/lib.rs
@@ -4,6 +4,7 @@ mod dns;
 mod http;
 mod ip2country;
 mod models;
+mod notifications;
 mod smtp;
 mod tcp;
 mod utils;

--- a/src/src/models/mod.rs
+++ b/src/src/models/mod.rs
@@ -124,6 +124,14 @@ pub struct ShareClaims {
     pub subdomain: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct NotificationSettings {
+    pub discord_webhook_url: String,
+    pub mattermost_webhook_url: String,
+    pub telegram_bot_token: String,
+    pub telegram_chat_id: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CacheMessage {
     pub cmd: String,

--- a/src/src/notifications/mod.rs
+++ b/src/src/notifications/mod.rs
@@ -1,0 +1,333 @@
+use crate::cache::Cache;
+use crate::models::NotificationSettings;
+use serde_json::Value;
+use std::sync::Arc;
+use tracing::{error, info, warn};
+
+const NOTIFICATION_KEY_PREFIX: &str = "notifications:";
+
+pub async fn get_settings(cache: &Arc<Cache>, subdomain: &str) -> NotificationSettings {
+    let key = format!("{NOTIFICATION_KEY_PREFIX}{subdomain}");
+    match cache.get(&key).await {
+        Ok(Some(json_str)) => serde_json::from_str(&json_str).unwrap_or_default(),
+        _ => NotificationSettings::default(),
+    }
+}
+
+pub async fn save_settings(
+    cache: &Arc<Cache>,
+    subdomain: &str,
+    settings: &NotificationSettings,
+) -> Result<(), String> {
+    let key = format!("{NOTIFICATION_KEY_PREFIX}{subdomain}");
+    let json_str =
+        serde_json::to_string(settings).map_err(|e| format!("Serialization error: {e}"))?;
+    cache
+        .set(&key, &json_str)
+        .await
+        .map_err(|e| format!("Cache error: {e}"))
+}
+
+pub async fn send_discord(message: &str, title: &str, webhook_url: &str) -> bool {
+    if webhook_url.is_empty() {
+        return false;
+    }
+    let client = reqwest::Client::new();
+    let payload = serde_json::json!({
+        "embeds": [{
+            "title": title,
+            "description": message,
+            "color": 0x00FF00
+        }]
+    });
+    match client.post(webhook_url).json(&payload).send().await {
+        Ok(resp) => {
+            if resp.status().is_success() {
+                true
+            } else {
+                warn!("Discord webhook returned status: {}", resp.status());
+                false
+            }
+        }
+        Err(e) => {
+            error!("Failed to send Discord notification: {e}");
+            false
+        }
+    }
+}
+
+pub async fn send_mattermost(message: &str, title: &str, webhook_url: &str) -> bool {
+    if webhook_url.is_empty() {
+        return false;
+    }
+    let client = reqwest::Client::new();
+    let payload = serde_json::json!({
+        "text": format!("**{title}**\n{message}")
+    });
+    match client.post(webhook_url).json(&payload).send().await {
+        Ok(resp) => {
+            if resp.status().is_success() {
+                true
+            } else {
+                warn!("Mattermost webhook returned status: {}", resp.status());
+                false
+            }
+        }
+        Err(e) => {
+            error!("Failed to send Mattermost notification: {e}");
+            false
+        }
+    }
+}
+
+pub async fn send_telegram(message: &str, title: &str, bot_token: &str, chat_id: &str) -> bool {
+    if bot_token.is_empty() || chat_id.is_empty() {
+        return false;
+    }
+    let client = reqwest::Client::new();
+    let url = format!("https://api.telegram.org/bot{bot_token}/sendMessage");
+    let payload = serde_json::json!({
+        "chat_id": chat_id,
+        "text": format!("<b>{title}</b>\n{message}"),
+        "parse_mode": "HTML"
+    });
+    match client.post(&url).json(&payload).send().await {
+        Ok(resp) => {
+            if resp.status().is_success() {
+                true
+            } else {
+                warn!("Telegram API returned status: {}", resp.status());
+                false
+            }
+        }
+        Err(e) => {
+            error!("Failed to send Telegram notification: {e}");
+            false
+        }
+    }
+}
+
+pub async fn send_test(cache: &Arc<Cache>, subdomain: &str, service: &str) -> Result<(), String> {
+    let settings = get_settings(cache, subdomain).await;
+    let msg = "This is a test notification from RequestRepo";
+    let title = "RequestRepo Test Notification";
+    match service.to_lowercase().as_str() {
+        "discord" => {
+            if settings.discord_webhook_url.is_empty() {
+                return Err("Discord webhook URL not configured".to_string());
+            }
+            if send_discord(msg, title, &settings.discord_webhook_url).await {
+                Ok(())
+            } else {
+                Err("Failed to send Discord notification".to_string())
+            }
+        }
+        "mattermost" => {
+            if settings.mattermost_webhook_url.is_empty() {
+                return Err("Mattermost webhook URL not configured".to_string());
+            }
+            if send_mattermost(msg, title, &settings.mattermost_webhook_url).await {
+                Ok(())
+            } else {
+                Err("Failed to send Mattermost notification".to_string())
+            }
+        }
+        "telegram" => {
+            if settings.telegram_bot_token.is_empty() || settings.telegram_chat_id.is_empty() {
+                return Err("Telegram bot token or chat ID not configured".to_string());
+            }
+            if send_telegram(
+                msg,
+                title,
+                &settings.telegram_bot_token,
+                &settings.telegram_chat_id,
+            )
+            .await
+            {
+                Ok(())
+            } else {
+                Err("Failed to send Telegram notification".to_string())
+            }
+        }
+        _ => Err(format!("Unknown service: {service}")),
+    }
+}
+
+fn format_http_request(req: &Value) -> String {
+    let method = req.get("method").and_then(|v| v.as_str()).unwrap_or("N/A");
+    let path = req.get("path").and_then(|v| v.as_str()).unwrap_or("N/A");
+    let ip = req.get("ip").and_then(|v| v.as_str()).unwrap_or("N/A");
+    let port = req.get("port").and_then(|v| v.as_i64()).unwrap_or(0);
+    let date = req.get("date").and_then(|v| v.as_i64()).unwrap_or(0);
+    let country = req.get("country").and_then(|v| v.as_str()).unwrap_or("N/A");
+    let headers_str = req
+        .get("headers")
+        .and_then(|v| v.as_object())
+        .map(|h| {
+            h.iter()
+                .map(|(k, v)| format!("{k}: {}", v.as_str().unwrap_or("")))
+                .collect::<Vec<_>>()
+                .join("\n")
+        })
+        .unwrap_or_default();
+    format!(
+        "**HTTP Request Received**\n\
+         Method: `{method}`\n\
+         Path: `{path}`\n\
+         IP: `{ip}`\n\
+         Port: `{port}`\n\
+         Time: `{date}`\n\
+         Country: `{country}`\n\
+         Headers:\n```\n{headers_str}\n```"
+    )
+}
+
+fn format_dns_request(req: &Value) -> String {
+    let query_type = req
+        .get("query_type")
+        .and_then(|v| v.as_str())
+        .unwrap_or("N/A");
+    let domain = req.get("domain").and_then(|v| v.as_str()).unwrap_or("N/A");
+    let ip = req.get("ip").and_then(|v| v.as_str()).unwrap_or("N/A");
+    let port = req.get("port").and_then(|v| v.as_i64()).unwrap_or(0);
+    let date = req.get("date").and_then(|v| v.as_i64()).unwrap_or(0);
+    let country = req.get("country").and_then(|v| v.as_str()).unwrap_or("N/A");
+    format!(
+        "**DNS Request Received**\n\
+         Type: `{query_type}`\n\
+         Name: `{domain}`\n\
+         IP: `{ip}`\n\
+         Port: `{port}`\n\
+         Time: `{date}`\n\
+         Country: `{country}`"
+    )
+}
+
+fn format_smtp_request(req: &Value) -> String {
+    let from = req.get("from").and_then(|v| v.as_str()).unwrap_or("N/A");
+    let to = req.get("to").and_then(|v| v.as_str()).unwrap_or("N/A");
+    let subject = req.get("subject").and_then(|v| v.as_str()).unwrap_or("N/A");
+    let command = req.get("command").and_then(|v| v.as_str()).unwrap_or("N/A");
+    let ip = req.get("ip").and_then(|v| v.as_str()).unwrap_or("N/A");
+    let port = req.get("port").and_then(|v| v.as_i64()).unwrap_or(0);
+    let date = req.get("date").and_then(|v| v.as_i64()).unwrap_or(0);
+    let country = req.get("country").and_then(|v| v.as_str()).unwrap_or("N/A");
+    format!(
+        "**SMTP Request Received**\n\
+         From: `{from}`\n\
+         To: `{to}`\n\
+         Subject: `{subject}`\n\
+         Command: `{command}`\n\
+         IP: `{ip}`\n\
+         Port: `{port}`\n\
+         Time: `{date}`\n\
+         Country: `{country}`"
+    )
+}
+
+pub async fn send_request_notification(
+    cache: &Arc<Cache>,
+    subdomain: &str,
+    service: &str,
+    log: &Value,
+    message: &str,
+    title: &str,
+) -> Result<(), String> {
+    let settings = get_settings(cache, subdomain).await;
+    let formatted = match log.get("type").and_then(|v| v.as_str()) {
+        Some("http") => format_http_request(log),
+        Some("dns") => format_dns_request(log),
+        Some("smtp") => format_smtp_request(log),
+        _ => message.to_string(),
+    };
+    match service.to_lowercase().as_str() {
+        "discord" => {
+            if settings.discord_webhook_url.is_empty() {
+                return Err("Discord not configured".to_string());
+            }
+            if send_discord(&formatted, title, &settings.discord_webhook_url).await {
+                Ok(())
+            } else {
+                Err("Failed to send Discord notification".to_string())
+            }
+        }
+        "mattermost" => {
+            if settings.mattermost_webhook_url.is_empty() {
+                return Err("Mattermost not configured".to_string());
+            }
+            if send_mattermost(&formatted, title, &settings.mattermost_webhook_url).await {
+                Ok(())
+            } else {
+                Err("Failed to send Mattermost notification".to_string())
+            }
+        }
+        "telegram" => {
+            if settings.telegram_bot_token.is_empty() || settings.telegram_chat_id.is_empty() {
+                return Err("Telegram not configured".to_string());
+            }
+            if send_telegram(
+                &formatted,
+                title,
+                &settings.telegram_bot_token,
+                &settings.telegram_chat_id,
+            )
+            .await
+            {
+                Ok(())
+            } else {
+                Err("Failed to send Telegram notification".to_string())
+            }
+        }
+        _ => Err(format!("Unknown service: {service}")),
+    }
+}
+
+pub async fn notify_all(cache: Arc<Cache>, subdomain: String, log: Value) {
+    let settings = get_settings(&cache, &subdomain).await;
+
+    if settings.discord_webhook_url.is_empty()
+        && settings.mattermost_webhook_url.is_empty()
+        && (settings.telegram_bot_token.is_empty() || settings.telegram_chat_id.is_empty())
+    {
+        return;
+    }
+
+    let formatted = match log.get("type").and_then(|v| v.as_str()) {
+        Some("http") => format_http_request(&log),
+        Some("dns") => format_dns_request(&log),
+        Some("smtp") => format_smtp_request(&log),
+        _ => return,
+    };
+
+    info!("Sending notifications for {subdomain}");
+
+    let title = "RequestRepo Notification";
+
+    if !settings.discord_webhook_url.is_empty() {
+        let url = settings.discord_webhook_url.clone();
+        let msg = formatted.clone();
+        let t = title.to_string();
+        tokio::spawn(async move {
+            send_discord(&msg, &t, &url).await;
+        });
+    }
+
+    if !settings.mattermost_webhook_url.is_empty() {
+        let url = settings.mattermost_webhook_url.clone();
+        let msg = formatted.clone();
+        let t = title.to_string();
+        tokio::spawn(async move {
+            send_mattermost(&msg, &t, &url).await;
+        });
+    }
+
+    if !settings.telegram_bot_token.is_empty() && !settings.telegram_chat_id.is_empty() {
+        let token = settings.telegram_bot_token.clone();
+        let chat_id = settings.telegram_chat_id.clone();
+        let msg = formatted;
+        let t = title.to_string();
+        tokio::spawn(async move {
+            send_telegram(&msg, &t, &token, &chat_id).await;
+        });
+    }
+}

--- a/src/src/smtp/mod.rs
+++ b/src/src/smtp/mod.rs
@@ -606,7 +606,7 @@ async fn log_smtp_request(
     mail_from: Option<&str>,
     rcpt_to: &[String],
     transaction_log: &str,
-    cache: &Cache,
+    cache: &Arc<Cache>,
     tx: &broadcast::Sender<CacheMessage>,
 ) -> Result<()> {
     let request_id = generate_request_id();
@@ -663,6 +663,18 @@ async fn log_smtp_request(
     // Push request to list
     let list_key = format!("requests:{subdomain}");
     cache.rpush(&list_key, &request_json).await?;
+
+    // Send notifications asynchronously
+    {
+        let cache = cache.clone();
+        let sub = subdomain.to_string();
+        let req_json = request_json.clone();
+        tokio::spawn(async move {
+            if let Ok(log) = serde_json::from_str::<serde_json::Value>(&req_json) {
+                crate::notifications::notify_all(cache, sub, log).await;
+            }
+        });
+    }
 
     let message = CacheMessage {
         cmd: "new_request".to_string(),


### PR DESCRIPTION
- Add frontend route and page for notification settings
- Implement API endpoints for managing notification settings and sending test notifications
- Support Discord, Mattermost, and Telegram webhooks
- Update Cargo.toml/Cargo.lock with required dependencies (tokio-rustls, mime, etc.)
- Add .DS_Store to .gitignore

## UI :
<img width="1290" height="867" alt="requestrepo" src="https://github.com/user-attachments/assets/56bdb5a9-4577-4009-8829-d523c1b5e8ac" />

## Telegram: 
<img width="1116" height="922" alt="telegram" src="https://github.com/user-attachments/assets/490a3fa6-4602-4c3e-a722-c35fcc497cbe" />

## Mattermost: 
<img width="1276" height="848" alt="mattermost" src="https://github.com/user-attachments/assets/4a5b0af8-66a9-4bad-a653-bdd92baaf4ea" />

## Discord:
<img width="917" height="858" alt="discord" src="https://github.com/user-attachments/assets/a2113638-a8a7-41bb-bdd1-028a3ab129e4" />
